### PR TITLE
Remove Kubic Media

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -25,10 +25,6 @@ products:
     distri: microos
     flavor: DVD
     version: '*'
-  microos-*-Kubic-DVD-x86_64:
-    distri: microos
-    flavor: Kubic-DVD
-    version: '*'
   opensuse-Tumbleweed-DVD-i586:
     distri: opensuse
     flavor: DVD
@@ -52,10 +48,6 @@ products:
   microos-*-MicroOS-Image-ContainerHost-x86_64:
     distri: microos
     flavor: MicroOS-Image-ContainerHost
-    version: Tumbleweed
-  microos-*-MicroOS-Image-Kubic-kubeadm-x86_64:
-    distri: microos
-    flavor: MicroOS-Image-Kubic-kubeadm
     version: Tumbleweed
   microos-*-MicroOS-Image-x86_64:
     distri: microos
@@ -151,19 +143,6 @@ scenarios:
           settings:
             DESKTOP: textmode
             YAML_SCHEDULE: schedule/sle-micro/remote_ssh_target.yaml
-    microos-*-Kubic-DVD-x86_64:
-      - rcshell:
-          machine: 64bit
-      - kubeadm:
-          machine: 64bit-2G-HD40G
-      - container-host:
-          machine: 64bit
-          settings:
-            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed
-      - container-host:
-          machine: uefi
-          settings:
-            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed
     microos-*-MicroOS-Image-ContainerHost-x86_64:
       - container-host:
           settings:
@@ -174,9 +153,6 @@ scenarios:
       - container-host-old2microosnext:
           settings:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed
-    microos-*-MicroOS-Image-Kubic-kubeadm-x86_64:
-      - kubeadm:
-          machine: 64bit-2G
     microos-*-MicroOS-Image-x86_64:
       - microos:
           settings:

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -22,10 +22,6 @@ products:
     distri: microos
     flavor: DVD
     version: '*'
-  microos-*-Kubic-DVD-aarch64:
-    distri: microos
-    flavor: Kubic-DVD
-    version: '*'
   opensuse-Tumbleweed-DVD-aarch64:
     distri: opensuse
     flavor: DVD
@@ -70,10 +66,6 @@ products:
     distri: microos
     flavor: MicroOS-Image-ContainerHost
     version: Tumbleweed
-  microos-*-MicroOS-Image-Kubic-kubeadm-aarch64:
-    distri: microos
-    flavor: MicroOS-Image-Kubic-kubeadm
-    version: Tumbleweed
   microos-*-MicroOS-Image-aarch64:
     distri: microos
     flavor: MicroOS-Image
@@ -111,15 +103,6 @@ scenarios:
             TIMEOUT_SCALE: '2'
             DESKTOP: textmode
             YAML_SCHEDULE: schedule/sle-micro/remote_ssh_target.yaml
-    microos-*-Kubic-DVD-aarch64:
-      - rcshell:
-          machine: aarch64
-      - kubeadm:
-          machine: aarch64-4G-HD40G
-      - container-host:
-          machine: aarch64-4G-HD40G
-          settings:
-            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/tumbleweed
     microos-*-MicroOS-Image-ContainerHost-aarch64:
       - container-host:
           settings:
@@ -131,8 +114,6 @@ scenarios:
       - container-host-old2microosnext:
           settings:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/tumbleweed
-    microos-*-MicroOS-Image-Kubic-kubeadm-aarch64:
-      - kubeadm
     microos-*-MicroOS-Image-aarch64:
       - microos:
           settings:

--- a/job_groups/staging_projects.yaml
+++ b/job_groups/staging_projects.yaml
@@ -20,10 +20,6 @@ products:
     distri: microos
     flavor: Staging-DVD
     version: '*'
-  microos-*-Staging-Kubic-DVD-x86_64:
-    distri: microos
-    flavor: Staging-Kubic-DVD
-    version: '*'
   opensuse-*-Staging-DVD-x86_64:
     distri: opensuse
     flavor: Staging-DVD
@@ -48,15 +44,6 @@ scenarios:
       - container-host-microos:
           testsuite: container-host
           machine: 64bit-2G-HD40G
-          settings:
-            CONTAINER_RUNTIME: podman
-            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed
-    microos-*-Staging-Kubic-DVD-x86_64:
-      - kubeadm:
-          machine: 64bit-2G-HD40G
-      - container-host-kubic:
-          testsuite: container-host
-          machine: uefi-staging
           settings:
             CONTAINER_RUNTIME: podman
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed


### PR DESCRIPTION
Kubic is being wound down, so we need to stop testing the media.