### PR TITLE
Use 15.4-GM-kde disk image on leap 15.5 zdup tests

### DIFF
--- a/job_groups/opensuse_leap_15.5_updates.yaml
+++ b/job_groups/opensuse_leap_15.5_updates.yaml
@@ -111,6 +111,7 @@ scenarios:
           settings:
             <<: *zdup
             QEMU_VIRTIO_RNG: "0"
+            HDD_1: '%DISTRI%-15.4-%ARCH%-GM-kde@%MACHINE%.qcow2'
       - upgrade_Leap_15.4_gnome:
           settings:
             QEMU_VIRTIO_RNG: "0"


### PR DESCRIPTION
https://progress.opensuse.org/issues/130471

[VR](https://openqa.opensuse.org/tests/3341547)