### PR TITLE
Add k3s related test suite variables

### DIFF
--- a/job_groups/opensuse_leap_15.4_updates.yaml
+++ b/job_groups/opensuse_leap_15.4_updates.yaml
@@ -157,12 +157,16 @@ scenarios:
             CONTAINER_RUNTIME: 'podman'
             START_AFTER_TEST: 'create_hdd_leap_textmode_autoyast'
             HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%_ay@%MACHINE%.qcow2'
+            K3S_SYMLINK: 'skip'
+            K8S_CLIENT: 'kubernetes1.24-client'
       - extra_tests_textmode_kubectl_containers:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIME: 'kubectl'
             START_AFTER_TEST: 'create_hdd_leap_textmode_autoyast'
             HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%_ay@%MACHINE%.qcow2'
+            K3S_SYMLINK: 'skip'
+            K8S_CLIENT: 'kubernetes1.24-client'
       - extra_tests_textmode_docker_containers:
           testsuite: extra_tests_textmode_containers
           settings:

--- a/job_groups/opensuse_leap_15.5_updates.yaml
+++ b/job_groups/opensuse_leap_15.5_updates.yaml
@@ -134,12 +134,16 @@ scenarios:
             CONTAINER_RUNTIME: 'podman'
             START_AFTER_TEST: 'create_hdd_leap_textmode_autoyast'
             HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%_ay@%MACHINE%.qcow2'
+            K3S_SYMLINK: 'skip'
+            K8S_CLIENT: 'kubernetes1.24-client'
       - extra_tests_textmode_kubectl_containers:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIME: 'kubectl'
             START_AFTER_TEST: 'create_hdd_leap_textmode_autoyast'
             HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%_ay@%MACHINE%.qcow2'
+            K3S_SYMLINK: 'skip'
+            K8S_CLIENT: 'kubernetes1.24-client'
       - extra_tests_textmode_docker_containers:
           testsuite: extra_tests_textmode_containers
           settings:

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -82,6 +82,7 @@ scenarios:
           machine: 64bit
           settings:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed
+            K3S_INSTALL_UPSTREAM: '1'
       - remote_ssh_controller:
           settings:
             HDD_1: support_server_tumbleweed@64bit.qcow2
@@ -97,12 +98,15 @@ scenarios:
       - container-host:
           settings:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed
+            K3S_INSTALL_UPSTREAM: '1'
       - container-host2microosnext:
           settings:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed
+            K3S_INSTALL_UPSTREAM: '1'
       - container-host-old2microosnext:
           settings:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed
+            K3S_INSTALL_UPSTREAM: '1'
     microos-*-MicroOS-Image-x86_64:
       - microos:
           settings:
@@ -265,6 +269,7 @@ scenarios:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIME: 'podman'
+            K3S_INSTALL_UPSTREAM: '1'
       - containers_host_containerd:
           testsuite: extra_tests_textmode_containers
           settings:
@@ -273,10 +278,12 @@ scenarios:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIME: 'helm'
+            K3S_INSTALL_UPSTREAM: '1'
       - containers_host_kubectl:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIME: 'kubectl'
+            K3S_INSTALL_UPSTREAM: '1'
       - containers_hpc_apptainer:
           testsuite: extra_tests_textmode_containers
           settings:
@@ -285,6 +292,7 @@ scenarios:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIME: 'docker,podman'
+            K3S_INSTALL_UPSTREAM: '1'
             CONTAINERS_UNTESTED_IMAGES: '1'
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed
             # Temporarily disabled due to db instance being down

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -88,6 +88,7 @@ scenarios:
           machine: aarch64-4G-HD40G
           settings:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/tumbleweed
+            K3S_INSTALL_UPSTREAM: '1'
       - remote_ssh_controller:
           priority: 45
           settings:
@@ -107,13 +108,16 @@ scenarios:
       - container-host:
           settings:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/tumbleweed
+            K3S_INSTALL_UPSTREAM: '1'
       - container-host2microosnext:
           settings:
             HDD_1_URL: 'http://download.opensuse.org/ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-ContainerHost-kvm-and-xen.qcow2?foo=%BUILD%'
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/tumbleweed
+            K3S_INSTALL_UPSTREAM: '1'
       - container-host-old2microosnext:
           settings:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/tumbleweed
+            K3S_INSTALL_UPSTREAM: '1'
     microos-*-MicroOS-Image-aarch64:
       - microos:
           settings:
@@ -246,14 +250,17 @@ scenarios:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIME: 'helm'
+            K3S_INSTALL_UPSTREAM: '1'
       - containers_host_kubectl:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIME: 'kubectl'
+            K3S_INSTALL_UPSTREAM: '1'
       - containers_host_podman:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIME: 'podman'
+            K3S_INSTALL_UPSTREAM: '1'
       - containers_host_containerd:
           testsuite: extra_tests_textmode_containers
           settings:
@@ -268,6 +275,7 @@ scenarios:
             CONTAINER_RUNTIME: 'docker,podman'
             CONTAINERS_UNTESTED_IMAGES: '1'
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/tumbleweed
+            K3S_INSTALL_UPSTREAM: '1'
             # Temporarily disabled due to db instance being down
             IMAGE_STORE_DATA: '0'
             POSTGRES_IP: '18.196.183.86'


### PR DESCRIPTION
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/17699 introduced more options in kubectl and k3s installation that is going to be used in k8s library. Add necessary variables into openSUSE tests