### PR TITLE
aardvark-dns: Use default tag by version and not latest

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -432,7 +432,6 @@ scenarios:
             RETRY: '1'
             BATS_PACKAGE: 'aardvark'
             BATS_SKIP: '100-basic-name-resolution 200-two-networks 300-three-networks'
-            BATS_URL: 'https://github.com/containers/aardvark-dns/archive/refs/heads/main.tar.gz'
       - container_host_netavark_testsuite:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats


### PR DESCRIPTION
aardvark-dns tests should use default tag by version and not latest main branch.

Verification run: https://openqa.opensuse.org/tests/5019050