### PR TITLE
kernel: Add YAML_SCHEDULE in kdump tests

### DIFF
--- a/job_groups/opensuse_tumbleweed_kernel.yaml
+++ b/job_groups/opensuse_tumbleweed_kernel.yaml
@@ -70,6 +70,7 @@ scenarios:
       - kdump:
           settings:
             CRASH_MEMORY: '320'
+            YAML_SCHEDULE: schedule/kernel/kdump.yaml
       - install_ltp+opensuse+DVD
       - ltp_aio_stress
       - ltp_aiodio_part1
@@ -229,6 +230,7 @@ scenarios:
       - kdump:
           settings:
             CRASH_MEMORY: '640'
+            YAML_SCHEDULE: schedule/kernel/kdump.yaml
       - install_ltp+opensuse+DVD
       - kernel-live-patching
       - ltp_aio_stress
@@ -349,7 +351,9 @@ scenarios:
       - extra_tests_kernel
       - bpftools
       - io_uring
-      - kdump
+      - kdump:
+          settings:
+            YAML_SCHEDULE: schedule/kernel/kdump.yaml
       - install_ltp+opensuse+DVD
       - ipsec_3hosts_support_server
       - ipsec_3hosts_left_node


### PR DESCRIPTION
This is needed because s390x does not use YAML_SCHEDULE so the test suite can't have this defined, so move it to the job group settings.

Related ticket: https://progress.opensuse.org/issues/182276