### PR TITLE
Run cryptlvm test also in uefi scenario

### DIFF
--- a/job_groups/staging_projects.yaml
+++ b/job_groups/staging_projects.yaml
@@ -86,6 +86,8 @@ scenarios:
           priority: 45
       - cryptlvm:
           machine: 64bit
+      - cryptlvm:
+          machine: uefi-staging
       - rescue_system:
           machine: 64bit
       - upgrade_staging:


### PR DESCRIPTION
In order to better cover the new bootloader default for TW run the same test
for both scenarios, with uefi and with legacy boot.

See also https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22187
