### PR TITLE
Update blackbox exporter

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -645,11 +645,11 @@ scenarios:
             BCI_IMAGE_MARKER: 389-ds_3.1
             BCI_TEST_ENVS: all,389ds,metadata
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/389-ds:3.1
-      - bci_blackbox_exporter_0.24_podman:
+      - bci_blackbox_exporter_podman:
           testsuite: null
           settings:
             <<: *bci
-            BCI_IMAGE_MARKER: blackbox_exporter_0.24
+            BCI_IMAGE_MARKER: blackbox_exporter_latest
             BCI_TEST_ENVS: all,metadata
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/blackbox_exporter:latest
       - bci_kiwi_podman:

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -504,11 +504,11 @@ scenarios:
             BCI_IMAGE_MARKER: 389-ds_3.1
             BCI_TEST_ENVS: all,389ds,metadata
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/389-ds:3.1
-      - bci_blackbox_exporter_0.24_podman:
+      - bci_blackbox_exporter_podman:
           testsuite: null
           settings:
             <<: *bci
-            BCI_IMAGE_MARKER: blackbox_exporter_0.24
+            BCI_IMAGE_MARKER: blackbox_exporter_latest
             BCI_TEST_ENVS: all,metadata
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/blackbox_exporter:latest
       - bci_kiwi_podman:


### PR DESCRIPTION
Update the blackbox exporter tag to use the generic `latest` tag instead of specific versions.

* Related ticket: https://progress.opensuse.org/issues/183332
* Verification run: https://openqa.opensuse.org/tests/5098499