### PR TITLE
Test crun with podman testsuite

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -400,6 +400,12 @@ scenarios:
             CONTAINER_RUNTIMES: 'podman'
             K3S_INSTALL_UPSTREAM: '1'
             SECURITY_MAC: 'selinux'
+      - container_host_podman_crun:
+          testsuite: extra_tests_textmode_containers
+          settings:
+            CONTAINER_RUNTIMES: 'podman'
+            K3S_INSTALL_UPSTREAM: '1'
+            OCI_RUNTIME: 'crun'
       - container_host_podman_tumbleweed:
           testsuite: extra_tests_textmode_containers
           settings:

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -337,6 +337,12 @@ scenarios:
             CONTAINER_RUNTIMES: 'podman'
             K3S_INSTALL_UPSTREAM: '1'
             SECURITY_MAC: 'selinux'
+      - container_host_podman_crun:
+          testsuite: extra_tests_textmode_containers
+          settings:
+            CONTAINER_RUNTIMES: 'podman'
+            K3S_INSTALL_UPSTREAM: '1'
+            OCI_RUNTIME: 'crun'
       - container_host_containerd:
           testsuite: extra_tests_textmode_containers
           settings:


### PR DESCRIPTION
Test crun with podman testsuite

Verification run: https://openqa.opensuse.org/tests/5098618#step/podman/54 (`OCI_RUNTIME=crun`)