### PR TITLE
Enlarge create_hdd_textmode HDDSIZEGB

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -324,6 +324,11 @@ scenarios:
       - minimalx_btrfs_snapper
       - create_hdd_textmode:
           priority: 45
+      - create_hdd_textmode_100G:
+          testsuite: create_hdd_textmode
+          settings:
+            +HDDSIZEGB: '100'
+            PUBLISH_HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%-100G@%MACHINE%.qcow2'
       - create_hdd_textmode_apparmor:
           priority: 45
           testsuite: 'create_hdd_textmode'


### PR DESCRIPTION
Some tests run after it need more HDDSIZEGB, the HDDSIZEGB of create_hdd_textmode will limit them. Enlarge it to avoid the no-space-left issue.

Ticket: https://progress.opensuse.org/issues/168298
Verification run: 
- https://openqa.opensuse.org/tests/5120149 (create_hdd_textmode job change HDDSIZEG=100 and modify the PUBLISH_HDD_1 and PUBLISH_PFLASH_VARS)
- https://openqa.opensuse.org/tests/5120190 (create_hdd_xfstests using the new HDD)
- https://openqa.opensuse.org/tests/5120194 (xfstests_xfs-xfs-001-100 using the new HDD)

Checking the VR result: 
create_hdd_textmode(done) -> create_hdd_xfstests(done) -> xfstests_xfs-xfs-001-100(done)
The target test disk size goes up: https://openqa.opensuse.org/tests/5120194#step/partition/94