### PR TITLE
Set PUBLISH_PFLASH_VARS value to null in create_hdd_textmode_100G

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -329,6 +329,7 @@ scenarios:
           settings:
             +HDDSIZEGB: '100'
             PUBLISH_HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%-100G@%MACHINE%.qcow2'
+            PUBLISH_PFLASH_VARS: ''
       - create_hdd_textmode_apparmor:
           priority: 45
           testsuite: 'create_hdd_textmode'


### PR DESCRIPTION
Progress ticket: https://progress.opensuse.org/issues/168298