### PR TITLE
Enable runc & skopeo BATS tests on aarch64

### DIFF
--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -395,6 +395,26 @@ scenarios:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIMES: 'containerd_crictl,containerd_nerdctl'
+      - container_host_runc_testsuite:
+          description: |-
+            Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats
+          testsuite: extra_tests_textmode_containers
+          settings:
+            BATS_PACKAGE: 'runc'
+            CONTAINER_RUNTIMES: 'podman'
+            QEMURAM: '4096'
+            QEMUCPUS: '2'
+            RETRY: '1'
+      - container_host_skopeo_testsuite:
+          description: |-
+            Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats
+          testsuite: extra_tests_textmode_containers
+          settings:
+            BATS_PACKAGE: 'skopeo'
+            CONTAINER_RUNTIMES: 'podman'
+            QEMURAM: '4096'
+            QEMUCPUS: '2'
+            RETRY: '1'
       - containers_hpc_apptainer:
           testsuite: extra_tests_textmode_containers
           settings:


### PR DESCRIPTION
Enable runc & skopeo BATS tests on aarch64

Note: For aardvark-dns, netavark & podman I have to figure out the best way to get the right version of ncat for this architecture. I don't plan to include buildah as it's more complex.

Verification runs:
- runc: https://openqa.opensuse.org/tests/5171763
- skopeo: https://openqa.opensuse.org/tests/5171764