### PR TITLE
Pin tests to either Legacy boot or UEFI ahead of grub2-bls switch

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -1075,7 +1075,6 @@ scenarios:
             DESKTOP: textmode
             YAML_SCHEDULE: schedule/security/build_nested_hdd.yaml
             PUBLISH_HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%@%MACHINE%_nested_l2.qcow2'
-      - security_pam
       - security_tpm2
       - security_tpm2_uefi:
           testsuite: security_tpm2


### PR DESCRIPTION
For grub2-bls switch, the default machine type should change to uefi as it (grub2-bls) doesn't work with legacy bios.

Ticket: https://progress.opensuse.org/issues/184861
VR: https://openqa.opensuse.org/tests/overview?distri=microos&distri=opensuse&version=Tumbleweed&build=20250825-uefi&groupid=1

BCI test failures are to be expected as they use this setting: `BCI_DEVEL_REPO: 'http://openqa.opensuse.org/assets/repo/openSUSE-%VERSION%-oss-%ARCH%-Snapshot%BUILD%'` which in the case of custom build id, causes internal test failures, as the repo doesn't exist
