### PR TITLE
LTP: Fix ltp_syscalls_kotd

### DIFF
--- a/job_groups/opensuse_tumbleweed_kernel.yaml
+++ b/job_groups/opensuse_tumbleweed_kernel.yaml
@@ -327,9 +327,6 @@ scenarios:
       - xfstests_nfs3-nfs
   s390x:
     opensuse-Tumbleweed-DVD-s390x:
-      - install_ltp_kotd+opensuse+DVD:
-          settings:
-            KOTD_REPO: 'https://download.opensuse.org/repositories/Kernel:/HEAD/S390/'
       - kdump:
           settings:
             KDUMP: '1'
@@ -354,6 +351,7 @@ scenarios:
             LTP_TAINT_EXPECTED: '0x13801'
       - ltp_syscalls_kotd:
           settings:
+            KOTD_REPO: 'https://download.opensuse.org/repositories/Kernel:/HEAD/S390/'
             LTP_TAINT_EXPECTED: '0x13801'
       - kernel-live-patching:
           settings:


### PR DESCRIPTION
This also reverts commit c973aee ("Schedule install_ltp_kotd for s390x").

s390x on o3 is special because it uses z/VM which does not share qcow2 images (unlike KVM), therefore each job needs to run install_ltp before running LTP runtest. Therefore KOTD_REPO setup needs to be directly in ltp_syscalls_kotd job.

Fixes: 9d071f4 ("Schedule ltp_syscalls_kotd on s390x")
Fixes: https://github.com/os-autoinst/opensuse-jobgroups/pull/723