### PR TITLE
Fix ltp_syscalls_kotd on s390x

### DIFF
--- a/job_groups/opensuse_tumbleweed_kernel.yaml
+++ b/job_groups/opensuse_tumbleweed_kernel.yaml
@@ -351,6 +351,7 @@ scenarios:
             LTP_TAINT_EXPECTED: '0x13801'
       - ltp_syscalls_kotd:
           settings:
+            INSTALL_KOTD: '1'
             KOTD_REPO: 'https://download.opensuse.org/repositories/Kernel:/HEAD/S390/'
             LTP_TAINT_EXPECTED: '0x13801'
       - kernel-live-patching:


### PR DESCRIPTION
ltp_syscalls_kotd on s390x requires due z/VM (not KVM thus not using qcow2) to specify INSTALL_KOTD=1. Other archs are tested on KVM, therefore they get this setup from install_ltp_kotd+opensuse+DVD.

Verification run: https://openqa.opensuse.org/tests/5297070

Fixes: 9d071f4 ("Schedule ltp_syscalls_kotd on s390x")
Fixes: abec9f5 ("LTP: Fix ltp_syscalls_kotd")
Reported-by: Avinesh Kumar <avinesh.kumar@suse.com>