### PR TITLE
kernel: Add kselftests-bpf-progs

### DIFF
--- a/job_groups/opensuse_tumbleweed_kernel.yaml
+++ b/job_groups/opensuse_tumbleweed_kernel.yaml
@@ -380,6 +380,7 @@ scenarios:
       - kernel-live-patching
       - kselftests-livepatch
       - kselftests-bpf
+      - kselftests-bpf-progs
       - ltp_aio_stress
       - ltp_aiodio_part1
       - ltp_aiodio_part2


### PR DESCRIPTION
**Prerequisites**: https://github.com/openSUSE/kernel-qe/pull/26

Related tickets:
- https://progress.opensuse.org/issues/187791
- https://progress.opensuse.org/issues/157186

Verification runs (`KSELFTEST_TESTS=bpf:test_progs,bpf:test_progs-no_alu32,bpf:test_progs-cpuv4`):
- https://openqa.opensuse.org/tests/5309580
- https://openqa.opensuse.org/tests/5309581
- https://openqa.opensuse.org/tests/5309582