### PR TITLE
Move podman-py test to podman_e2e

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -428,6 +428,13 @@ scenarios:
             CONTAINER_TESTS: 'docker_compose,python_runtime'
             QEMUCPUS: '2'
             QEMURAM: '4096'
+      - container_host_podman_e2e:
+          testsuite: extra_tests_textmode_containers
+          settings:
+            CONTAINER_RUNTIMES: 'podman'
+            CONTAINER_TESTS: 'python_runtime'
+            QEMUCPUS: '2'
+            QEMURAM: '4096'
       - container_host_podman_apparmor:
           testsuite: extra_tests_textmode_containers
           settings:


### PR DESCRIPTION
Depends on https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/23399
Verification run: https://openqa.opensuse.org/tests/5334771