### PR TITLE
Increate BCI TO as it is in SLES

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -18,7 +18,7 @@
   BCI_TESTS: "1"
   BCI_PREPARE: "1"
   BCI_TESTS_REPO: "https://github.com/SUSE/BCI-tests.git"
-  BCI_TIMEOUT: "5400"  # some tests take very long, specially in aarch64
+  BCI_TIMEOUT: "7200"  # some tests take very long, specially in aarch64
   QEMUCPUS: "2"
   QEMURAM: "4096"
   START_AFTER_TEST: "create_hdd_textmode"


### PR DESCRIPTION
Time out issue: [registry](https://openqa.opensuse.org/tests/5708804#step/bci_test_podman/56)
```
Terminated                 timeout 5400 tox -e all -- -rxX -n auto -k "registry" --reruns 3 --reruns-delay 10 | tee tox_all.txt
```