### PR TITLE
Add new tests for grub2-bls and grub2-efi in staging

### DIFF
--- a/job_groups/staging_projects.yaml
+++ b/job_groups/staging_projects.yaml
@@ -83,6 +83,20 @@ scenarios:
           priority: 45
       - minimalx:
           priority: 45
+      - minimalx-grub2-bls:
+          description: |
+            Test installation with grub2-bls
+          testsuite: minimalx
+          settings:
+            INSTALLONLY: '1'
+            BOOTLOADER: grub2-bls
+      - minimalx-grub2:
+          description: |
+            Test installation using grub2 (efi)
+          testsuite: minimalx
+          settings:
+            INSTALLONLY: '1'
+            BOOTLOADER: grub2
       - cryptlvm:
           machine: 64bit-2G
       - cryptlvm:


### PR DESCRIPTION
Needs https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/24762

VR: https://openqa.opensuse.org/tests/overview?version=Staging%3AH&build=systemd-boot-default&distri=opensuse

Additional VR:
- [grub2](https://openqa.opensuse.org/tests/5791353#step/grub_test/1)
- [grub2-bls](https://openqa.opensuse.org/tests/5791354#step/grub_test/1)
