### PR TITLE
chore(ci): bump checkout to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,12 @@ jobs:
     steps:
 
       - name: Git Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Git Checkout PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
@@ -72,7 +72,7 @@ jobs:
           ../tool.py --dry-run --push --github
 
       - name: Clone os-autoinst-distri-opensuse repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           repository: os-autoinst/os-autoinst-distri-opensuse 
           ref: refs/heads/master

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
 
       - name: Git Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
This also fixes a warning about outdated nodejs