### PR TITLE
Add TRANSACTIONAL_VALIDATION to MicroOS

### DIFF
--- a/job_groups/opensuse_leap_micro_6.0.yaml
+++ b/job_groups/opensuse_leap_micro_6.0.yaml
@@ -19,6 +19,7 @@
   HDDSIZEGB_1: '30'
   ENABLE_SELINUX: '1'
   FIRST_BOOT_CONFIG: 'combustion+ignition'
+  TRANSACTIONAL_VALIDATION: '1'
 
 .image_container_settings: &image_container_settings
   <<: *image_settings
@@ -55,7 +56,7 @@ defaults:
     settings:
       QEMUCPUS: '2'
 
-products: # ---Default---
+products:  # ---Default---
   leap-micro-6.0-Default-SelfInstall-x86_64: &distriver
     distri: leap-micro
     flavor: Default-SelfInstall

--- a/job_groups/opensuse_leap_micro_6.1.yaml
+++ b/job_groups/opensuse_leap_micro_6.1.yaml
@@ -22,6 +22,7 @@
   QEMURAM: '2048'
   ENABLE_SELINUX: '1'
   FIRST_BOOT_CONFIG: 'combustion+ignition'
+  TRANSACTIONAL_VALIDATION: '1'
 
 .image_container_settings: &image_container_settings
   <<: *image_settings
@@ -58,7 +59,7 @@ defaults:
     settings:
       QEMUCPUS: '2'
 
-products: # ---Default---
+products:  # ---Default---
   leap-micro-6.1-Default-SelfInstall-x86_64: &distriver
     distri: leap-micro
     flavor: Default-SelfInstall

--- a/job_groups/opensuse_leap_micro_6.2.yaml
+++ b/job_groups/opensuse_leap_micro_6.2.yaml
@@ -22,6 +22,7 @@
   QEMURAM: '2048'
   ENABLE_SELINUX: '1'
   FIRST_BOOT_CONFIG: 'combustion+ignition'
+  TRANSACTIONAL_VALIDATION: '1'
 
 .image_container_settings: &image_container_settings
   <<: *image_settings

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -162,14 +162,24 @@ scenarios:
           machine: uefi-2G
       - microos:
           machine: uefi
+          settings:
+            TRANSACTIONAL_VALIDATION: '1'
       - microos-sdboot:
           machine: uefi-2G
+          settings:
+            TRANSACTIONAL_VALIDATION: '1'
       - microos:
           machine: 64bit
+          settings:
+            TRANSACTIONAL_VALIDATION: '1'
       - microos_textmode:
           machine: uefi-2G
+          settings:
+            TRANSACTIONAL_VALIDATION: '1'
       - microos_textmode:
           machine: 64bit-2G
+          settings:
+            TRANSACTIONAL_VALIDATION: '1'
       - container_host:
           machine: uefi-2G
           settings:
@@ -206,31 +216,40 @@ scenarios:
           settings:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed
             K3S_INSTALL_UPSTREAM: '1'
+            TRANSACTIONAL_VALIDATION: '1'
       - fips-container_host:
           settings:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed
             K3S_INSTALL_UPSTREAM: '1'
             QEMUCPUS: '2'
+            TRANSACTIONAL_VALIDATION: '1'
       - container_host2microosnext:
           settings:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed
             K3S_INSTALL_UPSTREAM: '1'
             QEMUCPUS: '2'
+            TRANSACTIONAL_VALIDATION: '1'
       - container_host-old2microosnext:
           settings:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed
             K3S_INSTALL_UPSTREAM: '1'
             QEMUCPUS: '2'
+            TRANSACTIONAL_VALIDATION: '1'
     microos-*-MicroOS-Image-x86_64:
       - microos:
           settings:
             # SELinux is enabled by default, but this allows running some checks
             ENABLE_SELINUX: '1'
+            TRANSACTIONAL_VALIDATION: '1'
       - microos-combustion
       - microos-ignition
       - microos-wizard
-      - microos2microosnext
-      - microos-old2microosnext
+      - microos2microosnext:
+          settings:
+            TRANSACTIONAL_VALIDATION: '1'
+      - microos-old2microosnext:
+          settings:
+            TRANSACTIONAL_VALIDATION: '1'
       - microos_qemu:
           settings:
             QEMUCPU: 'host'
@@ -245,6 +264,8 @@ scenarios:
     microos-*-MicroOS-Image-sdboot-x86_64:
       - microos-combustion:
           machine: uefi
+          settings:
+            TRANSACTIONAL_VALIDATION: '1'
       - microos-combustion-fde:
           machine: uefi
           settings:
@@ -254,6 +275,7 @@ scenarios:
             HDD_2: 'extended_combustion.qcow2'
             NUMDISKS: '3'
             QEMU_DISABLE_SNAPSHOTS: '1'
+            TRANSACTIONAL_VALIDATION: '1'
       - microos-wizard-tpm:
           testsuite: microos-wizard
           machine: uefi
@@ -263,12 +285,14 @@ scenarios:
             # Test with TPM enrollment
             QEMUTPM: 'instance'
             QEMU_DISABLE_SNAPSHOTS: '1'
+            TRANSACTIONAL_VALIDATION: '1'
       - microos-wizard:
           machine: uefi
           settings:
             # jeos-firstboot sets up FDE by default
             ENCRYPT: '1'
             # Test without TPM enrollment
+            TRANSACTIONAL_VALIDATION: '1'
     microos-*-MicroOS-Image-grub-bls-x86_64:
       - microos-wizard:
           machine: uefi
@@ -276,6 +300,7 @@ scenarios:
             # jeos-firstboot sets up FDE by default
             ENCRYPT: '1'
             # Test without TPM enrollment
+            TRANSACTIONAL_VALIDATION: '1'
       - microos-wizard-tpm:
           testsuite: microos-wizard
           machine: uefi
@@ -285,8 +310,11 @@ scenarios:
             # Test with TPM enrollment
             QEMUTPM: 'instance'
             QEMU_DISABLE_SNAPSHOTS: '1'
+            TRANSACTIONAL_VALIDATION: '1'
     microos-*-MicroOS-SelfInstall-x86_64:
-      - microos
+      - microos:
+          settings:
+            TRANSACTIONAL_VALIDATION: '1'
     opensuse-Tumbleweed-DVD-x86_64:
       - textmode:
           machine: 64bit

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -136,10 +136,16 @@ scenarios:
       - microos_10G-disk
       - microos:
           machine: aarch64-4G-HD40G
+          settings:
+            TRANSACTIONAL_VALIDATION: '1'
       - microos-sdboot:
           machine: aarch64-4G-HD40G
+          settings:
+            TRANSACTIONAL_VALIDATION: '1'
       - microos_textmode:
           machine: aarch64-4G-HD40G
+          settings:
+            TRANSACTIONAL_VALIDATION: '1'
       - container-host:
           machine: aarch64-4G-HD40G
           settings:
@@ -170,34 +176,42 @@ scenarios:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/tumbleweed
             K3S_INSTALL_UPSTREAM: '1'
             QEMUCPUS: '2'
+            TRANSACTIONAL_VALIDATION: '1'
       - fips-container-host:
           settings:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/tumbleweed
             K3S_INSTALL_UPSTREAM: '1'
             QEMUCPUS: '2'
+            TRANSACTIONAL_VALIDATION: '1'
       - container-host2microosnext:
           settings:
             HDD_1_URL: 'http://download.opensuse.org/ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-ContainerHost-kvm-and-xen.qcow2?foo=%BUILD%'
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/tumbleweed
             K3S_INSTALL_UPSTREAM: '1'
             QEMUCPUS: '2'
+            TRANSACTIONAL_VALIDATION: '1'
       - container-host-old2microosnext:
           settings:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/tumbleweed
             K3S_INSTALL_UPSTREAM: '1'
             QEMUCPUS: '2'
+            TRANSACTIONAL_VALIDATION: '1'
     microos-*-MicroOS-Image-aarch64:
       - microos:
           settings:
             # SELinux is enabled by default, but this allows running some checks
             ENABLE_SELINUX: '1'
+            TRANSACTIONAL_VALIDATION: '1'
       - microos-combustion
       - microos-ignition
       - microos-wizard
       - microos2microosnext:
           settings:
             HDD_1_URL: 'http://download.opensuse.org/ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-kvm-and-xen.qcow2?foo=%BUILD%'
-      - microos-old2microosnext
+            TRANSACTIONAL_VALIDATION: '1'
+      - microos-old2microosnext:
+          settings:
+            TRANSACTIONAL_VALIDATION: '1'
       - microos_qemu:
           settings:
             EXCLUDE_MODULES: kvm
@@ -221,6 +235,7 @@ scenarios:
             HDD_2: 'extended_combustion.qcow2'
             NUMDISKS: '3'
             QEMU_DISABLE_SNAPSHOTS: '1'
+            TRANSACTIONAL_VALIDATION: '1'
       - microos-wizard-tpm:
           testsuite: microos-wizard
           settings:
@@ -229,6 +244,7 @@ scenarios:
             # Test with TPM enrollment
             QEMUTPM: 'instance'
             QEMU_DISABLE_SNAPSHOTS: '1'
+            TRANSACTIONAL_VALIDATION: '1'
       - microos-wizard:
           settings:
             # jeos-firstboot sets up FDE by default
@@ -240,6 +256,7 @@ scenarios:
             # jeos-firstboot sets up FDE by default
             ENCRYPT: '1'
             # Test without TPM enrollment
+            TRANSACTIONAL_VALIDATION: '1'
       - microos-wizard-tpm:
           testsuite: microos-wizard
           settings:
@@ -248,8 +265,11 @@ scenarios:
             # Test with TPM enrollment
             QEMUTPM: 'instance'
             QEMU_DISABLE_SNAPSHOTS: '1'
+            TRANSACTIONAL_VALIDATION: '1'
     microos-*-MicroOS-SelfInstall-aarch64:
-      - microos
+      - microos:
+          settings:
+            TRANSACTIONAL_VALIDATION: '1'
     opensuse-Tumbleweed-DVD-aarch64:
       - security_tpm2
       - unlock_luks2_volume_with_tpm2:

--- a/job_groups/staging_projects.yaml
+++ b/job_groups/staging_projects.yaml
@@ -151,6 +151,8 @@ scenarios:
     microos-*-Staging-MicroOS-Image-ContainerHost-x86_64:
       - microos:
           machine: 64bit
+          settings:
+            TRANSACTIONAL_VALIDATION: '1'
       - container-host:
           machine: 64bit
           settings:
@@ -168,3 +170,4 @@ scenarios:
             ENCRYPT: '1'
             # Test with TPM enrollment
             QEMUTPM: 'instance'
+            TRANSACTIONAL_VALIDATION: '1'


### PR DESCRIPTION
Run transactional role tests on all MicroOS images as they become a conditional test switch.

* Related ticket: https://progress.opensuse.org/issues/200063
* Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25396
* Verification run: [MicroOS](https://duck-norris.qe.suse.de/tests/61) and [Staging](https://duck-norris.qe.suse.de/tests/77)