### PR TITLE
Kselftests: Schedule net/mptcp

### DIFF
--- a/job_groups/opensuse_tumbleweed_kernel.yaml
+++ b/job_groups/opensuse_tumbleweed_kernel.yaml
@@ -389,6 +389,7 @@ scenarios:
       - kselftests-bpf-progs
       - kselftests-cgroup
       - kselftests-net
+      - kselftests-net_mptcp
       - ltp_aio_stress
       - ltp_aiodio_part1
       - ltp_aiodio_part2


### PR DESCRIPTION
VR: https://openqa.opensuse.org/tests/5870743

Clean green run, will be good to keep track of it for regressions.