### PR TITLE
Use a more recent snapshot to test transactional dup

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -232,6 +232,7 @@ scenarios:
       - container_host-old2microosnext:
           settings:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed
+            HDD_1: 'openSUSE-MicroOS.x86_64-ContainerHost-kvm-and-xen-old-20240812.qcow2'
             K3S_INSTALL_UPSTREAM: '1'
             QEMUCPUS: '2'
             TRANSACTIONAL_VALIDATION: '1'
@@ -249,6 +250,7 @@ scenarios:
             TRANSACTIONAL_VALIDATION: '1'
       - microos-old2microosnext:
           settings:
+            HDD_1: 'openSUSE-MicroOS.x86_64-ContainerHost-kvm-and-xen-old-20240812.qcow2'
             TRANSACTIONAL_VALIDATION: '1'
       - microos_qemu:
           settings:

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -194,6 +194,7 @@ scenarios:
           settings:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/tumbleweed
             K3S_INSTALL_UPSTREAM: '1'
+            HDD_1: 'openSUSE-MicroOS.aarch64-ContainerHost-kvm-and-xen-old-20240810.qcow2'
             QEMUCPUS: '2'
             TRANSACTIONAL_VALIDATION: '1'
     microos-*-MicroOS-Image-aarch64:
@@ -211,6 +212,7 @@ scenarios:
             TRANSACTIONAL_VALIDATION: '1'
       - microos-old2microosnext:
           settings:
+            HDD_1: 'openSUSE-MicroOS.aarch64-ContainerHost-kvm-and-xen-old-20240810.qcow2'
             TRANSACTIONAL_VALIDATION: '1'
       - microos_qemu:
           settings:


### PR DESCRIPTION
The previous image openSUSE-MicroOS.x86_64-kvm-and-xen-old.qcow2 has a very old version of podman (v4.3.2) that is older than the version in SLES 15-SP4+ (podman v4.9.5).  This version doesn't support the compose command, and we want to use docker-compose to test whether containers and other elements in the stack survive updates.

Use a more recent image.  This one for x86_64 has podman v5.2.0.

Related ticket: https://progress.opensuse.org/issues/183512

Verification runs:
- aarch64:
  - container-host-old2microosnext@aarch64 -> https://openqa.opensuse.org/tests/5879675
  - container-host-old2microosnext@aarch64 -> https://openqa.opensuse.org/tests/5879676
- x86_64:
  - microos-old2microosnext@uefi -> https://openqa.opensuse.org/tests/5879324
  - container_host-old2microosnext@uefi -> https://openqa.opensuse.org/tests/5879568