### PR TITLE
Smoke test K3S in MinimalVM

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -1676,6 +1676,11 @@ scenarios:
           machine: 64bit_virtio-2G
           settings:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed
+      - jeos-containers-k3s-smoketest:
+          machine: 64bit_virtio-2G
+          settings:
+            CONTAINER_RUNTIMES: "k3s"
+            CONTAINER_K3S_SMOKETEST: "1"
       - zdup_twjeos2twnext:
           machine: 64bit_virtio
       - jeos-filesystem:


### PR DESCRIPTION
Introduce a new smoke test for k3s in Minimal-VM.
Re-use existing functions ifrom lib/containers/k8s.pm as much as possible.

Schedule new test in Tumbleweed

- Related ticket: https://progress.opensuse.org/issues/199595