### PR TITLE
Some USB scenarios need BOOTFROM set to c

### DIFF
--- a/job_groups/opensuse_leap_16.1.yaml
+++ b/job_groups/opensuse_leap_16.1.yaml
@@ -94,6 +94,7 @@ scenarios:
           machine: uefi-usb-4G
           settings:
             <<: *agama
+            BOOTFROM: c
       - kde:
           machine: uefi-3G
           settings:
@@ -106,6 +107,7 @@ scenarios:
           machine: uefi-usb-4G
           settings:
             <<: *agama
+            BOOTFROM: c
     opensuse-offline-installer-x86_64:
       - gnome:
           machine: uefi-3G

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -334,8 +334,10 @@ scenarios:
           machine: 64bit
           priority: 45
       - uefi:
-          machine: USBboot_64
+          machine: uefi-usb-4G
           priority: 45
+          settings:
+            BOOTFROM: c
       - gnome:
           machine: Laptop_64
           priority: 45

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -292,6 +292,8 @@ scenarios:
           machine: aarch64
       - kde:
           machine: USBboot_aarch64
+          settings:
+            BOOTFROM: "c"
       - kde:
           machine: aarch64_no_lse_smp4
       - kde:
@@ -1281,6 +1283,8 @@ scenarios:
           priority: 40
       - kde-live_installation:
           machine: USBboot_aarch64-3G
+          settings:
+            BOOTFROM: "c"
       - kde_live_upgrade_leap_15.0:
           settings:
             QEMURAM: "3072"


### PR DESCRIPTION
Following up on #830 now Leap 16.1 doesn't have the boot from disk
option in the boot menu, and since the switch to systemd-boot as
bootloader, `BOOTFROM=c` is needed anyway

VR: https://openqa.opensuse.org/tests/overview?distri=opensuse&build=bootfrom

Goes together with: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25457
