### PR TITLE
Adopt openqa-investigate retry job status on upstream container tests

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -549,6 +549,7 @@ scenarios:
             QEMUCPUS: '2'
             QEMURAM: '4096'
             RETRY: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_docker_testsuite:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/README.md
@@ -560,6 +561,7 @@ scenarios:
             QEMUCPUS: '4'
             QEMURAM: '4096'
             RETRY: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_docker_rootless_testsuite:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/README.md
@@ -571,6 +573,7 @@ scenarios:
             QEMURAM: '4096'
             RETRY: '1'
             ROOTLESS: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_podman_e2e:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/README.md
@@ -581,6 +584,7 @@ scenarios:
             QEMUCPUS: '4'
             QEMURAM: '4096'
             RETRY: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_podman_rootless_e2e:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/README.md
@@ -592,6 +596,7 @@ scenarios:
             QEMURAM: '4096'
             RETRY: '1'
             ROOTLESS: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_podman_e2e_crun:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/README.md
@@ -603,6 +608,7 @@ scenarios:
             QEMURAM: '4096'
             OCI_RUNTIME: 'crun'
             RETRY: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_podman_rootless_e2e_crun:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/README.md
@@ -615,6 +621,7 @@ scenarios:
             OCI_RUNTIME: 'crun'
             RETRY: '1'
             ROOTLESS: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_podman_apparmor:
           testsuite: extra_tests_textmode_containers
           settings:
@@ -647,11 +654,12 @@ scenarios:
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats
           testsuite: extra_tests_textmode_containers
           settings:
+            BATS_PACKAGE: 'aardvark-dns'
             CONTAINER_RUNTIMES: 'podman'
             QEMURAM: '4096'
             QEMUCPUS: '2'
             RETRY: '1'
-            BATS_PACKAGE: 'aardvark-dns'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_buildah_testsuite:
           testsuite: extra_tests_textmode_containers
           description: |-
@@ -662,6 +670,7 @@ scenarios:
             QEMUCPU: 'host'
             QEMUCPUS: '2'
             RETRY: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_buildah_testsuite_crun:
           testsuite: extra_tests_textmode_containers
           description: |-
@@ -673,26 +682,29 @@ scenarios:
             QEMUCPUS: '2'
             OCI_RUNTIME: 'crun'
             RETRY: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_conmon_testsuite:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats
           testsuite: extra_tests_textmode_containers
           settings:
+            BATS_PACKAGE: 'conmon'
             CONTAINER_RUNTIMES: 'podman'
             QEMURAM: '4096'
             QEMUCPUS: '2'
             RETRY: '1'
-            BATS_PACKAGE: 'conmon'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_netavark_testsuite:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats
           testsuite: extra_tests_textmode_containers
           settings:
+            BATS_PACKAGE: 'netavark'
             CONTAINER_RUNTIMES: 'podman'
             QEMURAM: '4096'
             QEMUCPUS: '2'
             RETRY: '1'
-            BATS_PACKAGE: 'netavark'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_podman_testsuite:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats
@@ -704,6 +716,7 @@ scenarios:
             QEMUCPUS: '2'
             QEMURAM: '4096'
             RETRY: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_podman_testsuite_crun:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats
@@ -716,36 +729,40 @@ scenarios:
             QEMUCPUS: '2'
             QEMURAM: '4096'
             RETRY: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_runc_testsuite:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats
           testsuite: extra_tests_textmode_containers
           settings:
+            BATS_PACKAGE: 'runc'
             CONTAINER_RUNTIMES: 'podman'
             QEMURAM: '4096'
             QEMUCPUS: '2'
             RETRY: '1'
-            BATS_PACKAGE: 'runc'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_skopeo_testsuite:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats
           testsuite: extra_tests_textmode_containers
           settings:
+            BATS_PACKAGE: 'skopeo'
             CONTAINER_RUNTIMES: 'podman'
             QEMURAM: '4096'
             QEMUCPUS: '2'
             RETRY: '1'
-            BATS_PACKAGE: 'skopeo'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_umoci_testsuite:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats
           testsuite: extra_tests_textmode_containers
           settings:
+            BATS_PACKAGE: 'umoci'
             CONTAINER_RUNTIMES: 'podman'
             QEMURAM: '4096'
             QEMUCPUS: '2'
             RETRY: '1'
-            BATS_PACKAGE: 'umoci'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_containerd:
           testsuite: extra_tests_textmode_containers
           settings:

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -453,6 +453,7 @@ scenarios:
             QEMUCPU: 'host'
             QEMUCPUS: '2'
             RETRY: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_buildah_testsuite_crun:
           testsuite: extra_tests_textmode_containers
           description: |-
@@ -464,6 +465,7 @@ scenarios:
             QEMUCPUS: '2'
             OCI_RUNTIME: 'crun'
             RETRY: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_containerd_testsuite:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/README.md
@@ -474,6 +476,7 @@ scenarios:
             QEMUCPUS: '2'
             QEMURAM: '4096'
             RETRY: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_docker_testsuite:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/README.md
@@ -484,6 +487,7 @@ scenarios:
             QEMUCPUS: '4'
             QEMURAM: '4096'
             RETRY: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_docker_rootless_testsuite:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/README.md
@@ -495,6 +499,7 @@ scenarios:
             QEMURAM: '4096'
             RETRY: '1'
             ROOTLESS: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_aardvark_testsuite:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats
@@ -505,6 +510,7 @@ scenarios:
             QEMURAM: '4096'
             QEMUCPUS: '2'
             RETRY: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_conmon_testsuite:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats
@@ -515,6 +521,7 @@ scenarios:
             QEMURAM: '4096'
             QEMUCPUS: '2'
             RETRY: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_netavark_testsuite:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats
@@ -525,6 +532,7 @@ scenarios:
             QEMURAM: '4096'
             QEMUCPUS: '2'
             RETRY: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_podman_e2e:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/README.md
@@ -535,6 +543,7 @@ scenarios:
             QEMUCPUS: '4'
             QEMURAM: '4096'
             RETRY: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_podman_rootless_e2e:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/README.md
@@ -546,6 +555,7 @@ scenarios:
             QEMURAM: '4096'
             RETRY: '1'
             ROOTLESS: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_podman_e2e_crun:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/README.md
@@ -557,6 +567,7 @@ scenarios:
             QEMURAM: '4096'
             OCI_RUNTIME: 'crun'
             RETRY: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_podman_rootless_e2e_crun:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/README.md
@@ -569,6 +580,7 @@ scenarios:
             OCI_RUNTIME: 'crun'
             RETRY: '1'
             ROOTLESS: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_podman_testsuite:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats
@@ -580,6 +592,7 @@ scenarios:
             QEMURAM: '4096'
             QEMUCPUS: '2'
             RETRY: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_podman_testsuite_crun:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats
@@ -592,6 +605,7 @@ scenarios:
             QEMURAM: '4096'
             QEMUCPUS: '2'
             RETRY: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_runc_testsuite:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats
@@ -602,6 +616,7 @@ scenarios:
             QEMURAM: '4096'
             QEMUCPUS: '2'
             RETRY: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_skopeo_testsuite:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats
@@ -612,6 +627,7 @@ scenarios:
             QEMURAM: '4096'
             QEMUCPUS: '2'
             RETRY: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - containers_hpc_apptainer:
           testsuite: extra_tests_textmode_containers
           settings:

--- a/job_groups/opensuse_tumbleweed_powerpc.yaml
+++ b/job_groups/opensuse_tumbleweed_powerpc.yaml
@@ -92,6 +92,7 @@ scenarios:
             QEMUCPUS: '2'
             QEMURAM: '4096'
             RETRY: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_buildah_testsuite:
           testsuite: extra_tests_textmode_containers
           description: |-
@@ -102,6 +103,7 @@ scenarios:
             QEMUCPU: 'host'
             QEMUCPUS: '2'
             RETRY: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_buildah_testsuite_crun:
           testsuite: extra_tests_textmode_containers
           description: |-
@@ -113,6 +115,7 @@ scenarios:
             QEMUCPUS: '2'
             OCI_RUNTIME: 'crun'
             RETRY: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_containerd_testsuite:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/README.md
@@ -123,6 +126,7 @@ scenarios:
             QEMUCPUS: '2'
             QEMURAM: '4096'
             RETRY: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_docker_testsuite:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/README.md
@@ -134,6 +138,7 @@ scenarios:
             QEMUCPUS: '4'
             QEMURAM: '4096'
             RETRY: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_docker_rootless_testsuite:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/README.md
@@ -145,6 +150,7 @@ scenarios:
             QEMURAM: '4096'
             RETRY: '1'
             ROOTLESS: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_netavark_testsuite:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats
@@ -155,6 +161,7 @@ scenarios:
             QEMUCPUS: '2'
             QEMURAM: '4096'
             RETRY: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_podman_testsuite:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats
@@ -166,6 +173,7 @@ scenarios:
             QEMUCPUS: '2'
             QEMURAM: '4096'
             RETRY: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_podman_testsuite_crun:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats
@@ -178,6 +186,7 @@ scenarios:
             QEMUCPUS: '2'
             QEMURAM: '4096'
             RETRY: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_runc_testsuite:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats
@@ -188,6 +197,7 @@ scenarios:
             QEMUCPUS: '2'
             QEMURAM: '4096'
             RETRY: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - container_host_skopeo_testsuite:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats
@@ -198,6 +208,7 @@ scenarios:
             QEMUCPUS: '2'
             QEMURAM: '4096'
             RETRY: '1'
+            _FORCE_STATUS_ON_RETRY: '1'
       - extra_tests_filesystem
       - yast2_ncurses:
           settings:


### PR DESCRIPTION
Adopt openqa-investigate retry job status on upstream container tests like we're doing already on osd

Related ticket: https://progress.opensuse.org/issues/186708