### PR TITLE
Update RAM for lvm+RAID tests to 2G

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -1194,7 +1194,9 @@ scenarios:
             HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%-apparmor@%MACHINE%.qcow2'
       - security_misc_o3
       - lvm+RAID1:
-          machine: 64bit
+          machine: 64bit-2G
+          settings:
+            QEMURAM: '2048'
       - lvm-encrypt-separate-boot:
           machine: 64bit
           settings:


### PR DESCRIPTION
Recently this testsuite started to fail on Tumbleweed, turns out the SUT
didn't have enough memory and the installer among other processes were
getting OOM'd

VR: (See `lvm+RAID_2G` tests) 
- https://openqa.opensuse.org/tests/overview?&build=lvm_raid&distri=opensuse&version=Tumbleweed
