### PR TITLE
ltp: unschedule tests which are removed from ltp

### DIFF
--- a/job_groups/opensuse_tumbleweed_kernel.yaml
+++ b/job_groups/opensuse_tumbleweed_kernel.yaml
@@ -464,7 +464,6 @@ scenarios:
       - ltp_openposix:
           priority: 50
       - ltp_power_management_tests
-      - ltp_power_management_tests_exclusive
       - ltp_pty
       - ltp_sched
       - ltp_syscalls:


### PR DESCRIPTION
Unschedule runtest/power_management_tests_exclusive as all ltp tests under this has been removed. [0]

[0] https://github.com/linux-test-project/ltp/commit/f651947957faf10d6ceb4cd7df55299b18f3afea