### PR TITLE
Drop yast_oneclick_install test module: software.o.o is defuncd

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -1563,7 +1563,6 @@ scenarios:
             YAML_SCHEDULE: schedule/yast/opensuse/remote_vnc/remote_vnc_target.yaml
           description: The target of the vnc remote installation triggered by the controller
           testsuite: null
-      - yast_oneclick_install
       - firewalld-policy-firewall:
           machine: 64bit
           settings:

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -1034,7 +1034,6 @@ scenarios:
       - ping_client:
           priority: 45
       - install_offline
-      - yast_oneclick_install
       - nvme
       - selinux:
           description: Maintainer (Lily Zhao) llzhao@suse.com


### PR DESCRIPTION
Software.o.o is having massive issues, moreprominently on Leap than on
Tumbleweed, but is a point where fixing it seems more effort than
re-implementing a new portal. It is likely to go offline soon

Secondly, yast is being phased out and no development goes into it
