### PR TITLE
Added oqs_provider tests

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -1302,6 +1302,7 @@ scenarios:
             UEFI_PFLASH_VARS: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%@%MACHINE%-uefi-vars.qcow2'
           testsuite: null
       - desktopapps-gb18030
+      - oqs_provider
       - security_crypto_policies:
           testsuite: crypto_policies
       - security_audit:
@@ -2191,6 +2192,10 @@ scenarios:
           machine: uefi-3G
           settings:
             <<: *agama_gnome_recycled_testsuite
+      - oqs_provider:
+          machine: uefi-3G
+          settings:
+            <<: *agama_textmode_recycled_testsuite
       - qemu:
           machine: uefi-3G
           settings:

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -1134,6 +1134,7 @@ scenarios:
             SSS_USERNAME: 'wilber'
             YAML_SCHEDULE: schedule/security/389ds_sssd.yaml
       - installer_extended
+      - oqs_provider
     opensuse-Tumbleweed-GNOME-Live-aarch64:
       - gnome-live:
           machine: USBboot_aarch64-3G


### PR DESCRIPTION
https://progress.opensuse.org/issues/190398

Currently we lack oqs_provider test in Tumbleweed.

On SLE 16 we are executing it on x86_64, aarch64 and s390x.

Adding new oqs_provider test and will monitor how it works on TW.

VRs in Tumbleweed development group:

opensuse-Tumbleweed-DVD-x86_64: https://openqa.opensuse.org/tests/5993078
opensuse-Tumbleweed-DVD-aarch64: https://openqa.opensuse.org/tests/6001534
opensuse-Tumbleweed-agama-installer-x86_64: https://openqa.opensuse.org/tests/5993606