### PR TITLE
io_uring: Use 'from_git' option

### DIFF
--- a/job_groups/opensuse_tumbleweed_kernel.yaml
+++ b/job_groups/opensuse_tumbleweed_kernel.yaml
@@ -67,6 +67,7 @@ scenarios:
       - io_uring:
           settings:
             QEMUCPUS: '4'
+            LIBURING_INSTALL: 'from_git'
       - kdump:
           settings:
             CRASH_MEMORY: '320'
@@ -237,6 +238,7 @@ scenarios:
       - io_uring:
           settings:
             QEMUCPUS: '4'
+            LIBURING_INSTALL: 'from_git'
       - kdump:
           settings:
             CRASH_MEMORY: '640'
@@ -376,6 +378,7 @@ scenarios:
       - io_uring:
           settings:
             QEMUCPUS: '4'
+            LIBURING_INSTALL: 'from_git'
       - ipsec_3hosts_support_server
       - ipsec_3hosts_left_node
       - ipsec_3hosts_middle_node


### PR DESCRIPTION
The liburing-tests package will lag behind the kernel version, so in openSuse TW it makes sense to run it from git with cloning and then building on SUT as that allows to use very recent set of tests matching the kernel io_uring features

VR: https://openqa.opensuse.org/tests/5990414#step/io_uring/82