### PR TITLE
opensuse_tumbleweed_aarch64.yaml: 3G RAM for {GNOME,XFCE}-Live tests

### DIFF
--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -1136,7 +1136,7 @@ scenarios:
       - installer_extended
     opensuse-Tumbleweed-GNOME-Live-aarch64:
       - gnome-live:
-          machine: USBboot_aarch64
+          machine: USBboot_aarch64-3G
       - mediacheck:
           machine: USBboot_aarch64
           priority: 40
@@ -1389,7 +1389,7 @@ scenarios:
           machine: USBboot_aarch64
           priority: 40
       - xfce-live:
-          machine: USBboot_aarch64
+          machine: USBboot_aarch64-3G
     opensuse-Tumbleweed-WSL-aarch64:
       - wsl2-main:
           testsuite: null


### PR DESCRIPTION
Like for x86_64.

May avoid some random fails.