### PR TITLE
Excludes non-working modules on Leap 16.1

### DIFF
--- a/job_groups/opensuse_leap_16.1.yaml
+++ b/job_groups/opensuse_leap_16.1.yaml
@@ -24,6 +24,7 @@
   HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%-agama@%MACHINE%.qcow2'
   UEFI_PFLASH_VARS: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%-agama@%MACHINE%-uefi-vars.qcow2'
   START_AFTER_TEST: 'create_hdd_agama_gnome'
+  EXCLUDE_MODULES: 'steam,yast2_lan_restart,yast2_lan_device_settings,multi_users_dm,keyboard_layout_gdm,libqt5_qtbase'
 
 .agama_kde_recycled_testsuite: &agama_kde_recycled_testsuite
   NOAUTOLOGIN: '1'
@@ -166,16 +167,19 @@ scenarios:
           testsuite: desktop_amusement
           settings:
             DESKTOP: 'gnome'
+            EXCLUDE_MODULES: 'steam'
       - desktop_amusement_kde:
           machine: uefi-3G
           testsuite: desktop_amusement
           settings:
             DESKTOP: 'kde'
+            EXCLUDE_MODULES: 'steam'
       - desktop_amusement_xfce:
           machine: uefi-3G
           testsuite: desktop_amusement
           settings:
             DESKTOP: 'xfce'
+            EXCLUDE_MODULES: 'steam'
       - desktop_browsers_gnome:
           machine: uefi-3G
           testsuite: desktop_browsers
@@ -250,6 +254,8 @@ scenarios:
           machine: uefi-3G
       - textmode_extra_tests_networking:
           machine: uefi-3G
+          settings:
+            EXCLUDE_MODULES: 'yast2_lan_device_settings'
       - textmode_extra_tests_utils:
           machine: uefi-3G
       - toolkits:


### PR DESCRIPTION
* steam: no native steam on Leap 16 but flatpak
* yast2_lan_restart: yast2 is not available since libyui is no longer existing
* yast2_lan_device_settings: yast2 is not available since libyui is no longer existing
* multi_users_dm: would not work with gdm-systemd
* keyboard_layout_gdm: would not work with gdm-systemd
* libqt5_qtbase: yast2 inst_release_notes would not work because of yast2 basically is not available on Leap 16