### PR TITLE
Add KubeVirt containerDisk smoke test

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -1704,6 +1704,10 @@ scenarios:
           settings:
             CONTAINER_RUNTIMES: "k3s"
             CONTAINER_K3S_SMOKETEST: "1"
+      - jeos-containers-kubevirt-smoketest:
+          machine: uefi
+          settings:
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed-kubevirt-minimal
       - zdup_twjeos2twnext:
           machine: 64bit_virtio
       - jeos-filesystem:


### PR DESCRIPTION
Add an openQA smoke test for the Tumbleweed KubeVirt containerDisk image published in registry.opensuse.org.

The test deploys KubeVirt, creates a VirtualMachineInstance from the containerDisk image, injects cloud-init user data with an SSH key, and verifies that the guest boots, reports guest-agent connectivity, and is reachable over SSH.

- Related ticket: https://progress.opensuse.org/issues/199598
- Verification run:
  - https://openqa.opensuse.org/tests/6034303