### PR TITLE
Kselftests: Remove kselftests-bpf-progs

### DIFF
--- a/job_groups/opensuse_tumbleweed_kernel.yaml
+++ b/job_groups/opensuse_tumbleweed_kernel.yaml
@@ -422,7 +422,6 @@ scenarios:
       - kernel-live-patching
       - kselftests-livepatch
       - kselftests-bpf
-      - kselftests-bpf-progs
       - kselftests-cgroup
       - kselftests-net
       - kselftests-net_mptcp


### PR DESCRIPTION
The bpf:test_progs test will be ran in kselftests-bpf after the removal of the `kselftests` rpm package. Since the suite will be built at test runtime, it should be done just once.