### PR TITLE
Duplicate the amount of ram for the 2.10 branch of OBS

### DIFF
--- a/job_groups/obs_2.10.yaml
+++ b/job_groups/obs_2.10.yaml
@@ -20,4 +20,6 @@ products:
 scenarios:
   x86_64:
     obs-2.10-Appliance-x86_64:
-      - obs_appliance
+      - obs_appliance:
+          settings:
+            QEMURAM: '8192'


### PR DESCRIPTION
Increasing the resource cap for 2.10 in order to fix some spec failures