### PR TITLE
Tumbleweed (+AArch64): Add MicroOS BLS image tdup tests

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -293,6 +293,14 @@ scenarios:
             ENCRYPT: '1'
             # Test without TPM enrollment
             TRANSACTIONAL_VALIDATION: '1'
+      - microos2microosnext-combustion-fde:
+          settings:
+            +HDD_1: 'openSUSE-MicroOS.%ARCH%-kvm-and-xen-sdboot-before-%BUILD%.qcow2'
+            HDD_1_URL: 'http://download.opensuse.org/tumbleweed/appliances/openSUSE-MicroOS.x86_64-kvm-and-xen-sdboot.qcow2?foo=%BUILD%'
+      - microos-old2microosnext-combustion-fde:
+          testsuite: microos2microosnext-combustion-fde
+          settings:
+            +HDD_1: 'openSUSE-MicroOS.x86_64-16.0.0-kvm-and-xen-sdboot-Snapshot20260703.qcow2'
     microos-*-MicroOS-Image-grub-bls-x86_64:
       - microos-wizard:
           machine: uefi
@@ -311,6 +319,14 @@ scenarios:
             QEMUTPM: 'instance'
             QEMU_DISABLE_SNAPSHOTS: '1'
             TRANSACTIONAL_VALIDATION: '1'
+      - microos2microosnext-combustion-fde:
+          settings:
+            +HDD_1: 'openSUSE-MicroOS.%ARCH%-kvm-and-xen-grub-bls-before-%BUILD%.qcow2'
+            HDD_1_URL: 'http://download.opensuse.org/tumbleweed/appliances/openSUSE-MicroOS.x86_64-kvm-and-xen-grub-bls.qcow2?foo=%BUILD%'
+      - microos-old2microosnext-combustion-fde:
+          testsuite: microos2microosnext-combustion-fde
+          settings:
+            +HDD_1: 'openSUSE-MicroOS.x86_64-16.0.0-kvm-and-xen-grub-bls-Snapshot20260703.qcow2'
     microos-*-MicroOS-SelfInstall-x86_64:
       - microos:
           settings:

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -250,6 +250,14 @@ scenarios:
             # jeos-firstboot sets up FDE by default
             ENCRYPT: '1'
             # Test without TPM enrollment
+      - microos2microosnext-combustion-fde:
+          settings:
+            +HDD_1: 'openSUSE-MicroOS.%ARCH%-kvm-and-xen-sdboot-before-%BUILD%.qcow2'
+            HDD_1_URL: 'https://download.opensuse.org/ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-kvm-and-xen-sdboot.qcow2?foo=%BUILD%'
+      - microos-old2microosnext-combustion-fde:
+          testsuite: microos2microosnext-combustion-fde
+          settings:
+            +HDD_1: 'openSUSE-MicroOS.aarch64-16.0.0-kvm-and-xen-sdboot-Snapshot20260701.qcow2'
     microos-*-MicroOS-Image-grub-bls-aarch64:
       - microos-wizard:
           settings:
@@ -266,6 +274,14 @@ scenarios:
             QEMUTPM: 'instance'
             QEMU_DISABLE_SNAPSHOTS: '1'
             TRANSACTIONAL_VALIDATION: '1'
+      - microos2microosnext-combustion-fde:
+          settings:
+            +HDD_1: 'openSUSE-MicroOS.%ARCH%-kvm-and-xen-grub-bls-before-%BUILD%.qcow2'
+            HDD_1_URL: 'https://download.opensuse.org/ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-kvm-and-xen-grub-bls.qcow2?foo=%BUILD%'
+      - microos-old2microosnext-combustion-fde:
+          testsuite: microos2microosnext-combustion-fde
+          settings:
+            +HDD_1: 'openSUSE-MicroOS.aarch64-16.0.0-kvm-and-xen-grub-bls-Snapshot20260701.qcow2'
     microos-*-MicroOS-SelfInstall-aarch64:
       - microos:
           settings:


### PR DESCRIPTION
Move those from the dev group to the main groups.

VRs: https://openqa.opensuse.org/tests/overview?test=microos-old2microosnext-combustion-fde&test=microos2microosnext-combustion-fde&build=20260708&build=20260709&groupid=38