### PR TITLE
Remove python 3.11 from BCI tests

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -881,12 +881,6 @@ scenarios:
             <<: *bci
             BCI_IMAGE_MARKER: gcc_15
             BCI_TEST_ENVS: all,gcc
-      - bci_python_3.11_podman:
-          testsuite: null
-          settings:
-            <<: *bci
-            BCI_IMAGE_MARKER: python_3.11
-            BCI_TEST_ENVS: all,python
       - bci_python_3.13_podman:
           testsuite: null
           settings:

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -730,12 +730,6 @@ scenarios:
             <<: *bci
             BCI_IMAGE_MARKER: gcc_15
             BCI_TEST_ENVS: all,gcc
-      - bci_python_3.11_podman:
-          testsuite: null
-          settings:
-            <<: *bci
-            BCI_IMAGE_MARKER: python_3.11
-            BCI_TEST_ENVS: all,python
       - bci_python_3.13_podman:
           testsuite: null
           settings:


### PR DESCRIPTION
Most python-3.11-* modules have been [removed from the distribution].

[removed from the distribution]: https://lists.opensuse.org/archives/list/factory@lists.opensuse.org/thread/DIQ4RVAQZGVLXRCSR33AKKSCWMDOWR2B/
