### PR TITLE
BCI: Fix grafana image marker to use latest tag

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -994,7 +994,7 @@ scenarios:
           testsuite: null
           settings:
             <<: *bci
-            BCI_IMAGE_MARKER: grafana_11
+            BCI_IMAGE_MARKER: grafana_latest
             BCI_TEST_ENVS: all,grafana
       - bci_helm_latest_podman:
           testsuite: null

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -843,7 +843,7 @@ scenarios:
           testsuite: null
           settings:
             <<: *bci
-            BCI_IMAGE_MARKER: grafana_11
+            BCI_IMAGE_MARKER: grafana_latest
             BCI_TEST_ENVS: grafana
       - bci_helm_latest_podman:
           testsuite: null


### PR DESCRIPTION
Reference: https://progress.opensuse.org/issues/203088
VRs:
- https://openqa.opensuse.org/tests/6114665
- https://openqa.opensuse.org/tests/6114669