### PR TITLE
Don't run serverside checks if secrets are not defined

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
           yamllint -f github job_groups.yaml ${{ steps.changed-files.outputs.files }}
 
       - name: Check for orphaned yaml files
+        if: ${{ env.APISECRET != '' && env.APIKEY != '' }}
         env:
           APIKEY: "${{ secrets.APIKEY }}"
           APISECRET: "${{ secrets.APISECRET }}"
@@ -58,6 +59,7 @@ jobs:
           ../tool.py --orphans --github
 
       - name: Check for correct yaml headers
+        if: ${{ env.APISECRET != '' && env.APIKEY != '' }}
         env:
           APIKEY: "${{ secrets.APIKEY }}"
           APISECRET: "${{ secrets.APISECRET }}"
@@ -66,6 +68,7 @@ jobs:
           ../tool.py --headers --github
 
       - name: Run serverside checks
+        if: ${{ env.APISECRET != '' && env.APIKEY != '' }}
         env:
           APIKEY: "${{ secrets.APIKEY }}"
           APISECRET: "${{ secrets.APISECRET }}"


### PR DESCRIPTION
Looking at https://github.com/os-autoinst/opensuse-jobgroups/pull/882 there's [`CI / static-check (push) Failing`](https://github.com/os-autoinst/opensuse-jobgroups/actions/runs/30233310561/job/89876113841?pr=882) which is corresponding to the `push` event, we've known for a while that forks without proper secrets would fail this check and in turn if branch protection was enabled, requiring `status-check` to pass, GH would mark both events (`push` and `pull_request_target`) as required and block merge, despite `pull_request_target` passing.

Skipping these checks in case the secrets aren't available is a sensible option, specially with Dependabot enabled.

- With secrets (bad credentials on purpose, so it fails): https://github.com/foursixnine/opensuse-jobgroups/actions/runs/30275119176
- Without secrets: https://github.com/foursixnine/opensuse-jobgroups/actions/runs/30275119176
