### PR TITLE
Enable allow-unsafe-pr-checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
           repository: ${{github.event.pull_request.head.repo.full_name}}
           path: opensuse-jobgroups-pr
           fetch-depth: 0
+          allow-unsafe-pr-checkout: true # We may need to rework checks related to tool.py
 
       - name: Get modified job group yaml files
         id: changed-files


### PR DESCRIPTION
Since 1b72d567a5868e14dc39149bbfe332614769a9fc this option needs to be enabled, see[1].

https://github.com/os-autoinst/opensuse-jobgroups/actions/runs/30283665813/job/90036009881?pr=897#step:4:21
> Refusing to check out fork pull request code from a 'pull_request_target' workflow. This workflow runs with the base repository's GITHUB_TOKEN, secrets, default-branch cache scope, and runner access. Fetching and executing a fork's code in that trusted context commonly leads to "pwn request" vulnerabilities. To opt in, review the risks at https://gh.io/securely-using-pull_request_target and set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.

Workflow steps may need some love so the check that actually goes queries openQA may run
on a separate WF but that's for another PR :)

[1] https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target
