### PR TITLE
Revert "Disable pretty serial markers for jeos-cloud-init tests" as fix is available

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -1624,7 +1624,6 @@ scenarios:
           priority: 48
           machine: uefi_virtio-2G
           settings:
-            PRETTY_SERIAL_MARKERS: '0'
             NO_CLOUD: '1'
             HDD_2: cidata.qcow2
             CI_VERIFICATION: '1'

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -1157,7 +1157,6 @@ scenarios:
           machine: aarch64
           priority: 48
           settings:
-            PRETTY_SERIAL_MARKERS: '0'
             NO_CLOUD: '1'
             HDD_2: cidata.qcow2
             CI_VERIFICATION: '1'


### PR DESCRIPTION
Reverts os-autoinst/opensuse-jobgroups#895 as a fix is available in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/26194 (merged)