### PR TITLE
openSUSE_Tumbleweed: Fix wsl2_settings

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -1985,8 +1985,8 @@ scenarios:
             WSL_INSTALL_FROM: 'build'
             QEMU_ENABLE_SMBD: '1'
             WSL2: '1'
-            QEMUCPU: 'host,kvm=off,vmx=on,hypervisor=off,hv_time,hv_relaxed,hv_vapic,hv_spinlocks=0x1fff,hv_frequencies,hv_reenlightenment,hv_vpindex,hv-synic,hv-stimer,hv-stimer-direct'
-            QEMUMACHINE: 'q35,accel=whpx'
+            QEMUCPU: 'host,kvm=off,hypervisor=off,hv_time,hv_relaxed,hv_vapic,hv_spinlocks=0x1fff,hv_frequencies,hv_reenlightenment,hv_vpindex,hv-synic,hv-stimer,hv-stimer-direct'
+            QEMUMACHINE: 'q35'
             WORKER_CLASS: 'wsl2'
             WSL_FIRSTBOOT: 'yast'
       - wsl2-install-msstore:


### PR DESCRIPTION
"accel=whpx" makes no sense, that's for QEMU on Windows. It only "works" because a later "-enable-kvm" overwrote it.

"vmx=on" only works on Intel CPUs, but o3 workers use AMD, which use "svm=on". Both are the default anyway, just remove it.

Verification run: https://openqa.opensuse.org/tests/6134868