### PR TITLE
Remove clone_system from Tumbleweed schedule

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -1121,7 +1121,6 @@ scenarios:
           machine: uefi
       - extra_tests_filesystem
       - gnuhealth
-      - clone_system
       - wicked_basic_sut
       - wicked_basic_ref
       - wireguard_server


### PR DESCRIPTION
Test hasn't been passing for a long time due to different product bugs, so we've decided to unschedule.
