### PR TITLE
Unsechdule autoyast_reinstall_gnome

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -1085,9 +1085,6 @@ scenarios:
       - autoyast_gnome:
           machine: 64bit
       - autoyast_minimal
-      - autoyast_reinstall_gnome:
-          settings:
-            YAML_TEST_DATA: test_data/yast/opensuse/autoyast_reinstall/autoyast_reinstall_64bit.yaml
       - autoyast_rules_and_classes:
           description: Test verifies rules and classes autoyast.
           settings:


### PR DESCRIPTION
In #902, the clone_system job was unscheduled, which was the parent to autoyast_reinstall_gnome. Without the parent, there is no way to run the child task